### PR TITLE
Add iproute2 package to include ip command

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,7 @@
 FROM python:3.11-slim
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y iproute2 && \
+    rm -rf /var/lib/apt/lists/*
 COPY . /app
 WORKDIR /app
 RUN pip install .


### PR DESCRIPTION
### Summary :memo:
`iproute2` package added to `Containerfile` to include the `ip` command needed for the `net_option` features.

### Details
`Containerfile` is extended with a RUN statement to install the `iproute2` Debian package.

### Checks
- [X] Closed #3 
- [X] Tested Changes
