### PR TITLE
Add option to set ip and bring up interface

### DIFF
--- a/docker_overdose/containermanager.py
+++ b/docker_overdose/containermanager.py
@@ -165,6 +165,39 @@ class ProcessManager:
         )
         print("OK")
 
+    def intf_set_ip(self, intf, ipaddress):
+        print(
+            f"[{self.name}] Setting IP address {ipaddress} on interface '{intf}'...",  # noqa : E501
+            end="",
+        )
+        self.exec_in_ns(
+            [
+                IP_BIN,
+                "addr",
+                "add",
+                ipaddress,
+                "dev",
+                intf,
+            ]
+        )
+        print("OK")
+
+    def intf_up(self, intf):
+        print(
+            f"[{self.name}] Bringing interface '{intf}' up...",
+            end="",
+        )
+        self.exec_in_ns(
+            [
+                IP_BIN,
+                "link",
+                "set",
+                intf,
+                "up",
+            ]
+        )
+        print("OK")
+
 
 class ContainerManager(ProcessManager):
     def __init__(
@@ -247,6 +280,8 @@ class ContainerManager(ProcessManager):
                 continue
             whitelist = (
                 "add_if",
+                "intf_set_ip",
+                "intf_up",
                 "delete_default_route",
                 "change_default_route",
                 "add_route",


### PR DESCRIPTION
### Summary :memo:
Added option to set an IP address on an interface and to set an interface to 'up'.

### Details
1. Added methods to ProcessManager to set an IP address (`intf_set_ip`) and to bring an interface up (`intf_up`).
2. Added the methods to the options whitelist.

### Checks
- [X] Closed #5 
- [X] Closed #6 
- [X] Tested Changes
